### PR TITLE
Don't start fingerprint for FOD devices early

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -38,6 +38,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.content.pm.UserInfo;
 import android.hardware.biometrics.BiometricSourceType;
 import android.media.AudioAttributes;
@@ -99,6 +100,7 @@ import com.android.systemui.statusbar.phone.NotificationPanelViewController;
 import com.android.systemui.statusbar.phone.StatusBar;
 import com.android.systemui.util.DeviceConfigProxy;
 import com.android.systemui.util.InjectionInflationController;
+import com.android.internal.util.custom.FodUtils;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -379,6 +381,8 @@ public class KeyguardViewMediator extends SystemUI implements Dumpable {
     private boolean mWakeAndUnlocking;
     private IKeyguardDrawnCallback mDrawnCallback;
     private CharSequence mCustomMessage;
+
+    private boolean mHasFod;
 
     private final DeviceConfig.OnPropertiesChangedListener mOnPropertiesChangedListener =
             new DeviceConfig.OnPropertiesChangedListener() {
@@ -748,6 +752,8 @@ public class KeyguardViewMediator extends SystemUI implements Dumpable {
                 QuickStepContract.isGesturalMode(navigationModeController.addListener(mode -> {
                     mInGestureNavigationMode = QuickStepContract.isGesturalMode(mode);
                 }));
+        PackageManager packageManager = context.getPackageManager();
+        mHasFod = FodUtils.hasFodSupport(mContext);
     }
 
     public void userActivity() {
@@ -878,7 +884,9 @@ public class KeyguardViewMediator extends SystemUI implements Dumpable {
             // explicitly DO NOT want to call
             // mKeyguardViewControllerLazy.get().setKeyguardGoingAwayState(false)
             // here, since that will mess with the device lock state.
-            mUpdateMonitor.dispatchKeyguardGoingAway(false);
+            if (!mHasFod) {
+                mUpdateMonitor.dispatchKeyguardGoingAway(false);
+            }
 
             // Lock immediately based on setting if secure (user has a pin/pattern/password).
             // This also "locks" the device when not secure to provide easy access to the


### PR DESCRIPTION
commit 5cece5336229f5a15d481c8da02844e8307be0a4 causes fingerprint to start early
while going to sleep and this is not the expected behaviour for devices
with FOD since we have to apply DIM and HBM simultaneously which causes
device to give flicker effect while putting phone to sleep.

[daniml3 - arrowos]: adapt for non lineage platform

Change-Id: I67b4cdbc92556b54c6e865f2332732a35f2eec57