### PR TITLE
base: Add Touch HIDL support

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -265,11 +265,11 @@ java_library {
         "android.hardware.vibrator-V2-java",
         "android.system.suspend.control.internal-java",
         "devicepolicyprotosnano",
-
         "com.android.sysprop.apex",
         "com.android.sysprop.init",
         "com.android.sysprop.localization",
         "PlatformProperties",
+        "vendor.lineage.touch-V1.0-java",
     ],
     sdk_version: "core_platform",
     installable: false,

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4865,6 +4865,12 @@ public final class Settings {
         public static final String ANIMATOR_DURATION_SCALE = Global.ANIMATOR_DURATION_SCALE;
 
         /**
+         * Whether or not to vibrate when a touchscreen gesture is detected
+         * @hide
+         */
+        public static final String TOUCHSCREEN_GESTURE_HAPTIC_FEEDBACK = "touchscreen_gesture_haptic_feedback";
+
+        /**
          * Control whether the accelerometer will be used to change screen
          * orientation.  If 0, it will not be used unless explicitly requested
          * by the application; if 1, it will be used by default unless explicitly

--- a/core/java/com/android/internal/superior/hardware/HIDLHelper.java
+++ b/core/java/com/android/internal/superior/hardware/HIDLHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.superior.hardware;
+
+import android.util.Range;
+
+import java.util.ArrayList;
+
+class HIDLHelper {
+
+    static TouchscreenGesture[] fromHIDLGestures(
+            ArrayList<vendor.lineage.touch.V1_0.Gesture> gestures) {
+        int size = gestures.size();
+        TouchscreenGesture[] r = new TouchscreenGesture[size];
+        for (int i = 0; i < size; i++) {
+            vendor.lineage.touch.V1_0.Gesture g = gestures.get(i);
+            r[i] = new TouchscreenGesture(g.id, g.name, g.keycode);
+        }
+        return r;
+    }
+
+    static vendor.lineage.touch.V1_0.Gesture toHIDLGesture(TouchscreenGesture gesture) {
+        vendor.lineage.touch.V1_0.Gesture g = new vendor.lineage.touch.V1_0.Gesture();
+        g.id = gesture.id;
+        g.name = gesture.name;
+        g.keycode = gesture.keycode;
+        return g;
+    }
+
+}

--- a/core/java/com/android/internal/superior/hardware/LineageHardwareManager.java
+++ b/core/java/com/android/internal/superior/hardware/LineageHardwareManager.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2015-2016 The CyanogenMod Project
+ *               2017-2019 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.internal.superior.hardware;
+
+import android.content.Context;
+import android.hidl.base.V1_0.IBase;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.os.ServiceManager;
+import android.util.ArrayMap;
+import android.util.Log;
+import android.util.Range;
+
+import com.android.internal.annotations.VisibleForTesting;
+import com.android.internal.util.ArrayUtils;
+
+import com.android.internal.superior.hardware.HIDLHelper;
+
+import vendor.lineage.touch.V1_0.IGloveMode;
+import vendor.lineage.touch.V1_0.IKeyDisabler;
+import vendor.lineage.touch.V1_0.IStylusMode;
+import vendor.lineage.touch.V1_0.ITouchscreenGesture;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.IllegalArgumentException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Manages access to LineageOS hardware extensions
+ *
+ *  <p>
+ *  This manager requires the HARDWARE_ABSTRACTION_ACCESS permission.
+ *  <p>
+ *  To get the instance of this class, utilize LineageHardwareManager#getInstance(Context context)
+ */
+public final class LineageHardwareManager {
+    private static final String TAG = "LineageHardwareManager";
+
+    // The VisibleForTesting annotation is to ensure Proguard doesn't remove these
+    // fields, as they might be used via reflection. When the @Keep annotation in
+    // the support library is properly handled in the platform, we should change this.
+
+    /**
+     * High touch sensitivity for touch panels
+     */
+    @VisibleForTesting
+    public static final int FEATURE_HIGH_TOUCH_SENSITIVITY = 0x10;
+
+    /**
+     * Hardware navigation key disablement
+     */
+    @VisibleForTesting
+    public static final int FEATURE_KEY_DISABLE = 0x20;
+
+    /**
+     * Touchscreen hovering
+     */
+    @VisibleForTesting
+    public static final int FEATURE_TOUCH_HOVERING = 0x800;
+
+    /**
+     * Touchscreen gesture
+     */
+    @VisibleForTesting
+    public static final int FEATURE_TOUCHSCREEN_GESTURES = 0x80000;
+
+    private static final List<Integer> BOOLEAN_FEATURES = Arrays.asList(
+        FEATURE_HIGH_TOUCH_SENSITIVITY,
+        FEATURE_KEY_DISABLE,
+        FEATURE_TOUCH_HOVERING
+    );
+
+    private static LineageHardwareManager sLineageHardwareManagerInstance;
+
+    private Context mContext;
+
+    // HIDL hals
+    private HashMap<Integer, IBase> mHIDLMap = new HashMap<Integer, IBase>();
+
+    /**
+     * @hide to prevent subclassing from outside of the framework
+     */
+    private LineageHardwareManager(Context context) {
+        Context appContext = context.getApplicationContext();
+        if (appContext != null) {
+            mContext = appContext;
+        } else {
+            mContext = context;
+        }
+    }
+
+    /**
+     * Determine if a Lineage Hardware feature is supported on this device
+     *
+     * @param feature The Lineage Hardware feature to query
+     *
+     * @return true if the feature is supported, false otherwise.
+     */
+    public boolean isSupported(int feature) {
+        return isSupportedHIDL(feature);
+    }
+
+    private boolean isSupportedHIDL(int feature) {
+        if (!mHIDLMap.containsKey(feature)) {
+            mHIDLMap.put(feature, getHIDLService(feature));
+        }
+        return mHIDLMap.get(feature) != null;
+    }
+
+    private IBase getHIDLService(int feature) {
+        try {
+            switch (feature) {
+                case FEATURE_HIGH_TOUCH_SENSITIVITY:
+                    return IGloveMode.getService(true);
+                case FEATURE_KEY_DISABLE:
+                    return IKeyDisabler.getService(true);
+                case FEATURE_TOUCH_HOVERING:
+                    return IStylusMode.getService(true);
+                case FEATURE_TOUCHSCREEN_GESTURES:
+                    return ITouchscreenGesture.getService(true);
+            }
+        } catch (NoSuchElementException | RemoteException e) {
+        }
+        return null;
+    }
+
+    /**
+     * Get or create an instance of the {@link com.android.internal.custom.hardware.LineageHardwareManager}
+     * @param context
+     * @return {@link LineageHardwareManager}
+     */
+    public static LineageHardwareManager getInstance(Context context) {
+        if (sLineageHardwareManagerInstance == null) {
+            sLineageHardwareManagerInstance = new LineageHardwareManager(context);
+        }
+        return sLineageHardwareManagerInstance;
+    }
+
+    /**
+     * Determine if the given feature is enabled or disabled.
+     *
+     * Only used for features which have simple enable/disable controls.
+     *
+     * @param feature the Lineage Hardware feature to query
+     *
+     * @return true if the feature is enabled, false otherwise.
+     */
+    public boolean get(int feature) {
+        if (!BOOLEAN_FEATURES.contains(feature)) {
+            throw new IllegalArgumentException(feature + " is not a boolean");
+        }
+
+        try {
+            if (isSupportedHIDL(feature)) {
+                IBase obj = mHIDLMap.get(feature);
+                switch (feature) {
+                    case FEATURE_HIGH_TOUCH_SENSITIVITY:
+                        IGloveMode gloveMode = (IGloveMode) obj;
+                        return gloveMode.isEnabled();
+                    case FEATURE_KEY_DISABLE:
+                        IKeyDisabler keyDisabler = (IKeyDisabler) obj;
+                        return keyDisabler.isEnabled();
+                    case FEATURE_TOUCH_HOVERING:
+                        IStylusMode stylusMode = (IStylusMode) obj;
+                        return stylusMode.isEnabled();
+                }
+            }
+        } catch (RemoteException e) {
+        }
+        return false;
+    }
+
+    /**
+     * Enable or disable the given feature
+     *
+     * Only used for features which have simple enable/disable controls.
+     *
+     * @param feature the Lineage Hardware feature to set
+     * @param enable true to enable, false to disale
+     *
+     * @return true if the feature is enabled, false otherwise.
+     */
+    public boolean set(int feature, boolean enable) {
+        if (!BOOLEAN_FEATURES.contains(feature)) {
+            throw new IllegalArgumentException(feature + " is not a boolean");
+        }
+
+        try {
+            if (isSupportedHIDL(feature)) {
+                IBase obj = mHIDLMap.get(feature);
+                switch (feature) {
+                    case FEATURE_HIGH_TOUCH_SENSITIVITY:
+                        IGloveMode gloveMode = (IGloveMode) obj;
+                        return gloveMode.setEnabled(enable);
+                    case FEATURE_KEY_DISABLE:
+                        IKeyDisabler keyDisabler = (IKeyDisabler) obj;
+                        return keyDisabler.setEnabled(enable);
+                    case FEATURE_TOUCH_HOVERING:
+                        IStylusMode stylusMode = (IStylusMode) obj;
+                        return stylusMode.setEnabled(enable);
+                }
+            }
+        } catch (RemoteException e) {
+        }
+        return false;
+    }
+
+    /**
+     * @return a list of available touchscreen gestures on the devices
+     */
+    public TouchscreenGesture[] getTouchscreenGestures() {
+        try {
+            if (isSupportedHIDL(FEATURE_TOUCHSCREEN_GESTURES)) {
+                ITouchscreenGesture touchscreenGesture = (ITouchscreenGesture)
+                        mHIDLMap.get(FEATURE_TOUCHSCREEN_GESTURES);
+                return HIDLHelper.fromHIDLGestures(touchscreenGesture.getSupportedGestures());
+            }
+        } catch (RemoteException e) {
+        }
+        return null;
+    }
+
+    /**
+     * @return true if setting the activation status was successful
+     */
+    public boolean setTouchscreenGestureEnabled(
+            TouchscreenGesture gesture, boolean state) {
+        try {
+            if (isSupportedHIDL(FEATURE_TOUCHSCREEN_GESTURES)) {
+                ITouchscreenGesture touchscreenGesture = (ITouchscreenGesture)
+                        mHIDLMap.get(FEATURE_TOUCHSCREEN_GESTURES);
+                return touchscreenGesture.setGestureEnabled(
+                        HIDLHelper.toHIDLGesture(gesture), state);
+            }
+        } catch (RemoteException e) {
+        }
+        return false;
+    }
+}

--- a/core/java/com/android/internal/superior/hardware/TouchscreenGesture.aidl
+++ b/core/java/com/android/internal/superior/hardware/TouchscreenGesture.aidl
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *               2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.superior.hardware;
+
+parcelable TouchscreenGesture;

--- a/core/java/com/android/internal/superior/hardware/TouchscreenGesture.java
+++ b/core/java/com/android/internal/superior/hardware/TouchscreenGesture.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *               2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.superior.hardware;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Touchscreen gestures API
+ *
+ * A device may implement several touchscreen gestures for use while
+ * the display is turned off, such as drawing alphabets and shapes.
+ * These gestures can be interpreted by userspace to activate certain
+ * actions and launch certain apps, such as to skip music tracks,
+ * to turn on the flashlight, or to launch the camera app.
+ *
+ * This *should always* be supported by the hardware directly.
+ * A lot of recent touch controllers have a firmware option for this.
+ *
+ * This API provides support for enumerating the gestures
+ * supported by the touchscreen.
+ *
+ * A TouchscreenGesture is referenced by it's identifier and carries an
+ * associated name (up to the user to translate this value).
+ */
+public class TouchscreenGesture implements Parcelable {
+
+    public final int id;
+    public final String name;
+    public final int keycode;
+
+    public TouchscreenGesture(int id, String name, int keycode) {
+        this.id = id;
+        this.name = name;
+        this.keycode = keycode;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int flags) {
+        parcel.writeInt(id);
+        parcel.writeString(name);
+        parcel.writeInt(keycode);
+    }
+
+    /** @hide */
+    public static final Parcelable.Creator<TouchscreenGesture> CREATOR =
+            new Parcelable.Creator<TouchscreenGesture>() {
+
+        public TouchscreenGesture createFromParcel(Parcel in) {
+            return new TouchscreenGesture(in.readInt(), in.readString(), in.readInt());
+        }
+
+        @Override
+        public TouchscreenGesture[] newArray(int size) {
+            return new TouchscreenGesture[size];
+        }
+    };
+}


### PR DESCRIPTION
All credits to LineageOS and related authors on:
https://github.com/LineageOS/android_lineage-sdk

Ported to AOSP from lineage-sdk by SKULSHADY

[ anirudhgupta109 | AOSiP ]
 - Minimal import of LineageHardwareManager and HIDLHelper
 - We don't want LiveDisplay stuff
 - Nuke Legacy touchscreen support

matt0301 edit: refactor for SuperiorOS, this is needed for some off screen gestures on some devices, specially Oneplus ones

Change-Id: Ic8ca90663582c06f35562286f5ce5b2d84971ec4
Signed-off-by: Anirudh Gupta <anirudhgupta109@gmail.com>