### PR TITLE
SystemUI: Implement lockscreen quick unlock [1/2]

### DIFF
--- a/core/java/com/android/internal/widget/LockPatternUtils.java
+++ b/core/java/com/android/internal/widget/LockPatternUtils.java
@@ -83,6 +83,11 @@ public class LockPatternUtils {
     public static final String LEGACY_LOCK_PATTERN_ENABLED = "legacy_lock_pattern_enabled";
 
     /**
+     * The key to store PIN/Password length for quick unlock.
+     **/
+    public static final String KEY_PIN_PASSWORD_LENGTH = "pin_password_length";
+
+    /**
      * The interval of the countdown for showing progress of the lockout.
      */
     public static final long FAILED_ATTEMPT_COUNTDOWN_INTERVAL_MS = 1000L;
@@ -1785,6 +1790,25 @@ public class LockPatternUtils {
             getLockSettings().removeCachedUnifiedChallenge(userId);
         } catch (RemoteException re) {
             re.rethrowFromSystemServer();
+        }
+    }
+
+    public int getPinPasswordLength(int userId) {
+        int mPinPasswordLength = -1;
+        try {
+            mPinPasswordLength = (int) getLockSettings().getLong(KEY_PIN_PASSWORD_LENGTH, -1,
+                    userId);
+        } catch (Exception e) {
+            Log.d("getPinPasswordLength", "getLong error: " + e.getMessage());
+        }
+        return mPinPasswordLength;
+    }
+
+    public void setPinPasswordLength(int length, int userId) {
+        try {
+            getLockSettings().setLong(KEY_PIN_PASSWORD_LENGTH, (long) length, userId);
+        } catch (Exception e) {
+            Log.d("savePinPasswordLength", "saveLong error: " + e.getMessage());
         }
     }
 }

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputViewController.java
@@ -175,6 +175,9 @@ public abstract class KeyguardAbsKeyInputViewController<T extends KeyguardAbsKey
     void onPasswordChecked(int userId, boolean matched, int timeoutMs, boolean isValidPassword) {
         boolean dismissKeyguard = KeyguardUpdateMonitor.getCurrentUser() == userId;
         if (matched) {
+            if (mLockPatternUtils.getPinPasswordLength(userId) == -1) {
+                mLockPatternUtils.setPinPasswordLength(mView.getEnteredCredential().size(), userId);
+            }
             getKeyguardSecurityCallback().reportUnlockAttempt(userId, true, 0);
             if (dismissKeyguard) {
                 mDismissing = true;

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPasswordViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPasswordViewController.java
@@ -56,6 +56,7 @@ public class KeyguardPasswordViewController
     private final InputMethodManager mInputMethodManager;
     private final DelayableExecutor mMainExecutor;
     private final KeyguardViewController mKeyguardViewController;
+    private final LockPatternUtils mLockPatternUtils;
     private final boolean mShowImeAtScreenOn;
     private EditText mPasswordEntry;
     private ImageView mSwitchImeButton;
@@ -91,6 +92,10 @@ public class KeyguardPasswordViewController
         public void afterTextChanged(Editable s) {
             if (!TextUtils.isEmpty(s)) {
                 onUserInput();
+                if (s.length() == mLockPatternUtils.getPinPasswordLength(
+                        KeyguardUpdateMonitor.getCurrentUser())) {
+                    verifyPasswordAndUnlock();
+                }
             }
         }
     };
@@ -130,6 +135,7 @@ public class KeyguardPasswordViewController
         mShowImeAtScreenOn = resources.getBoolean(R.bool.kg_show_ime_at_screen_on);
         mPasswordEntry = mView.findViewById(mView.getPasswordTextViewId());
         mSwitchImeButton = mView.findViewById(R.id.switch_ime_button);
+        mLockPatternUtils = lockPatternUtils;
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPinViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPinViewController.java
@@ -16,7 +16,12 @@
 
 package com.android.keyguard;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.view.View;
+import android.widget.LinearLayout;
+
+import androidx.constraintlayout.helper.widget.Flow;
 
 import com.android.internal.util.LatencyTracker;
 import com.android.internal.widget.LockPatternUtils;
@@ -24,6 +29,12 @@ import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
 import com.android.systemui.R;
 import com.android.systemui.classifier.FalsingCollector;
 import com.android.systemui.statusbar.policy.DevicePostureController;
+import com.android.keyguard.PasswordTextView.QuickUnlockListener;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.List;
 
 public class KeyguardPinViewController
         extends KeyguardPinBasedInputViewController<KeyguardPINView> {
@@ -31,6 +42,9 @@ public class KeyguardPinViewController
     private final DevicePostureController mPostureController;
     private final DevicePostureController.Callback mPostureCallback = posture ->
             mView.onDevicePostureChanged(posture);
+    private final LockPatternUtils mLockPatternUtils;
+    private final View mDeleteButton;
+    private boolean mDeleteButtonShowing = true;
 
     protected KeyguardPinViewController(KeyguardPINView view,
             KeyguardUpdateMonitor keyguardUpdateMonitor,
@@ -46,11 +60,50 @@ public class KeyguardPinViewController
                 emergencyButtonController, falsingCollector);
         mKeyguardUpdateMonitor = keyguardUpdateMonitor;
         mPostureController = postureController;
+        mLockPatternUtils = lockPatternUtils;
+        mDeleteButton = mView.findViewById(R.id.delete_button);
     }
 
     @Override
     protected void onViewAttached() {
         super.onViewAttached();
+
+        int passwordLength = mLockPatternUtils.getPinPasswordLength(
+                KeyguardUpdateMonitor.getCurrentUser());
+
+        mPasswordEntry.setQuickUnlockListener(new QuickUnlockListener() {
+            public void onValidateQuickUnlock(String password) {
+                if (password != null) {
+                    int length = password.length();
+                    if (length > 0) {
+                        showDeleteButton(true, true);
+                    } else if (length == 0) {
+                        showDeleteButton(false, true);
+                    }
+                    if (length == passwordLength) {
+                        verifyPasswordAndUnlock();
+                    }
+                }
+            }
+        });
+
+        showDeleteButton(false, false);
+
+        View okButton = mView.findViewById(R.id.key_enter);
+        if (okButton != null) {
+            /* show okButton only if password length is unset
+               because quick unlock won't work */
+            if (passwordLength != -1) {
+                okButton.setVisibility(View.INVISIBLE);
+                Flow flow = (Flow) mView.findViewById(R.id.flow1);
+                if (flow != null) {
+                    List<Integer> ids = Arrays.stream(flow.getReferencedIds())
+                                            .boxed().collect(Collectors.toList());
+                    Collections.swap(ids, 9 /* delete_button */, 11 /* key_enter */);
+                    flow.setReferencedIds(ids.stream().mapToInt(i -> i).toArray());
+                }
+            }
+        }
 
         View cancelBtn = mView.findViewById(R.id.cancel_button);
         if (cancelBtn != null) {
@@ -79,11 +132,38 @@ public class KeyguardPinViewController
     void resetState() {
         super.resetState();
         mMessageAreaController.setMessage("");
+        showDeleteButton(false, false);
     }
 
     @Override
     public boolean startDisappearAnimation(Runnable finishRunnable) {
         return mView.startDisappearAnimation(
                 mKeyguardUpdateMonitor.needsSlowUnlockTransition(), finishRunnable);
+    }
+
+    private void showDeleteButton(boolean show, boolean animate) {
+        int visibility = show ? View.VISIBLE : View.INVISIBLE;
+        if (mDeleteButton != null && mDeleteButtonShowing != show) {
+            mDeleteButtonShowing = show;
+            if (animate) {
+                mDeleteButton.setAlpha(show ? 0.0f : 1.0f);
+                mDeleteButton.animate()
+                    .alpha(show ? 1.0f : 0.0f)
+                    .setDuration(show ? 250 : 450)
+                    .setListener(new AnimatorListenerAdapter() {
+                        @Override
+                        public void onAnimationStart(Animator animation) {
+                            if (show) mDeleteButton.setVisibility(visibility);
+                        }
+
+                        @Override
+                        public void onAnimationEnd(Animator animation) {
+                            if (!show) mDeleteButton.setVisibility(visibility);
+                        }
+                    });
+            } else {
+                mDeleteButton.setVisibility(visibility);
+            }
+        }
     }
 }

--- a/packages/SystemUI/src/com/android/keyguard/PasswordTextView.java
+++ b/packages/SystemUI/src/com/android/keyguard/PasswordTextView.java
@@ -102,9 +102,23 @@ public class PasswordTextView extends View {
     private Interpolator mFastOutSlowInInterpolator;
     private boolean mShowPassword;
     private UserActivityListener mUserActivityListener;
+    protected QuickUnlockListener mQuickUnlockListener;
 
     public interface UserActivityListener {
         void onUserActivity();
+    }
+
+    /* Quick unlock management for PIN view. */
+    public interface QuickUnlockListener {
+        /**
+         * Validate current password and prepare callback if verified.
+         * @param password The password string to be verified.
+         */
+        void onValidateQuickUnlock(String password);
+    }
+
+    public void setQuickUnlockListener(QuickUnlockListener listener) {
+        mQuickUnlockListener = listener;
     }
 
     public PasswordTextView(Context context) {
@@ -265,6 +279,10 @@ public class PasswordTextView extends View {
         }
         userActivity();
         sendAccessibilityEventTypeViewTextChanged(textbefore, textbefore.length(), 0, 1);
+
+        if (mQuickUnlockListener != null) {
+            mQuickUnlockListener.onValidateQuickUnlock(mText);
+        }
     }
 
     public void setUserActivityListener(UserActivityListener userActivitiListener) {
@@ -288,6 +306,9 @@ public class PasswordTextView extends View {
             sendAccessibilityEventTypeViewTextChanged(textbefore, textbefore.length() - 1, 1, 0);
         }
         userActivity();
+        if (mQuickUnlockListener != null) {
+            mQuickUnlockListener.onValidateQuickUnlock(mText);
+        }
     }
 
     public String getText() {
@@ -352,6 +373,9 @@ public class PasswordTextView extends View {
         }
         if (announce) {
             sendAccessibilityEventTypeViewTextChanged(textbefore, 0, textbefore.length(), 0);
+        }
+        if (mQuickUnlockListener != null) {
+            mQuickUnlockListener.onValidateQuickUnlock(mText);
         }
     }
 


### PR DESCRIPTION
[BigBrother1984 <carlosavignano@aospa.co>]:
    * PasswordTextView QuickUnlock listener functions and method

[mydongistiny <jaysonedson@gmail.com>]:
    * Forward port to Android 8 / 10

[SagarMakhar <sagarmakhar@gmail.com>]:
    * Forward port to Android 12

[Hikari-no-Tenshi <kyryljan.serhij@gmail.com>]:
    * Make Quick Unlock compatible with long PIN/Password (Idea from OOS)
    * Use AsyncTask for PIN/Password check.
    * Restore call on main thread check.

[Hernán Castañón <herna@paranoidandroid.co>]:
    * Make it independent of toggle (enabled by default)

[Jyotiraditya Panda <jyotiraditya@aospa.co>]:
    * Code cleanup and format
    * Hide Ok button in favour of quick unlock
    * Move backspace button to right

[ghostrider-reborn <gh0strider.2k18.reborn@gmail.com>]:
    * Simplify and refactor to use verifyPasswordAndUnlock()
    * Handle case where password length is not set
    * Hide backspace button when PIN is empty
    * Adapt to 12L - thanks to Jyotiraditya

Signed-off-by: mydongistiny <jaysonedson@gmail.com>
Signed-off-by: SagarMakhar <sagarmakhar@gmail.com>
Signed-off-by: Hernán Castañón <herna@paranoidandroid.co>
Signed-off-by: Jyotiraditya Panda <jyotiraditya@aospa.co>
Co-authored-by: BigBrother1984 <carlosavignano@aospa.co>
Co-authored-by: Hikari-no-Tenshi <kyryljan.serhij@gmail.com>
Co-authored-by: Adithya R <gh0strider.2k18.reborn@gmail.com>
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>
Change-Id: I1d721ad454fe4a37868071ef978468a12c844a03