### PR TITLE
base: Implement cutout force full screen [1/2]

### DIFF
--- a/core/java/android/app/IActivityManager.aidl
+++ b/core/java/android/app/IActivityManager.aidl
@@ -733,4 +733,9 @@ interface IActivityManager {
      *  Should disable touch if three fingers to screen shot is active?
      */
     boolean isSwipeToScreenshotGestureActive();
+
+    /**
+     *  Force full screen for devices with cutout
+     */
+    boolean shouldForceCutoutFullscreen(in String packageName);
 }

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5826,10 +5826,13 @@ public final class Settings {
         public static final String THREE_FINGER_GESTURE = "three_finger_gesture";
 
         /**
-         * Whether user can swap the order of the Alert Slider.
-         * * Whether user can invert the order of the Alert Slider.
-         * 0: Default
-         * 1: Inverted
+         * Force full screen for devices with cutout
+         * @hide
+         */
+        public static final String FORCE_FULLSCREEN_CUTOUT_APPS = "force_full_screen_cutout_apps";
+
+        /**
+         * Whether or not to vibrate when back gesture is used
          * @hide
          */
         public static final String ALERT_SLIDER_ORDER = "alert_slider_order";
@@ -5993,6 +5996,7 @@ public final class Settings {
             PRIVATE_SETTINGS.add(STATUSBAR_CLOCK_DATE_FORMAT);
             PRIVATE_SETTINGS.add(STATUSBAR_CLOCK_DATE_POSITION);
             PRIVATE_SETTINGS.add(LOCKSCREEN_QUICK_UNLOCK_CONTROL);
+            PRIVATE_SETTINGS.add(FORCE_FULLSCREEN_CUTOUT_APPS);
         }
 
         /**

--- a/core/java/com/android/internal/policy/PhoneWindow.java
+++ b/core/java/com/android/internal/policy/PhoneWindow.java
@@ -31,6 +31,7 @@ import static android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATIO
 import static android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
 import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
 import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT;
+import static android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
 import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_FORCE_DRAW_BAR_BACKGROUNDS;
 import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_NO_MOVE_ANIMATION;
 
@@ -2529,6 +2530,16 @@ public class PhoneWindow extends Window implements MenuBuilder.Callback {
                         + a.getString(R.styleable.Window_windowLayoutInDisplayCutoutMode));
             }
             params.layoutInDisplayCutoutMode = mode;
+        }
+
+        if (ActivityManager.isSystemReady()) {
+            try {
+                String packageName = context.getBasePackageName();
+                if (ActivityManager.getService().shouldForceCutoutFullscreen(packageName)){
+                    params.layoutInDisplayCutoutMode = LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+                }
+            } catch (RemoteException e) {
+            }
         }
 
         if (mAlwaysReadCloseOnTouchAttr || getContext().getApplicationInfo().targetSdkVersion

--- a/core/java/com/android/internal/util/custom/cutout/CutoutFullscreenController.java
+++ b/core/java/com/android/internal/util/custom/cutout/CutoutFullscreenController.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2018 The LineageOS project
+ * Copyright (C) 2019 The PixelExperience project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.util.custom.cutout;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.Resources;
+import android.database.ContentObserver;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.UserHandle;
+import android.text.TextUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import android.provider.Settings;
+
+public class CutoutFullscreenController {
+    private Set<String> mApps = new HashSet<>();
+    private Context mContext;
+
+    private final boolean isAvailable;
+
+    public CutoutFullscreenController(Context context) {
+        mContext = context;
+        final Resources resources = mContext.getResources();
+
+	final String displayCutout = resources.getString(com.android.internal.R.string.config_mainBuiltInDisplayCutout);
+        isAvailable = !TextUtils.isEmpty(displayCutout);
+
+        if (!isAvailable) {
+            return;
+        }
+
+        SettingsObserver observer = new SettingsObserver(
+                new Handler(Looper.getMainLooper()));
+        observer.observe();
+    }
+
+    public boolean isSupported() {
+        return isAvailable;
+    }
+
+    public boolean shouldForceCutoutFullscreen(String packageName) {
+        return isSupported() && mApps.contains(packageName);
+    }
+
+    public Set<String> getApps() {
+        return mApps;
+    }
+
+    public void addApp(String packageName) {
+        mApps.add(packageName);
+        Settings.System.putString(mContext.getContentResolver(),
+                Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS, String.join(",", mApps));
+    }
+
+    public void removeApp(String packageName) {
+        mApps.remove(packageName);
+        Settings.System.putString(mContext.getContentResolver(),
+                Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS, String.join(",", mApps));
+    }
+
+    public void setApps(Set<String> apps) {
+        mApps = apps;
+    }
+
+    class SettingsObserver extends ContentObserver {
+        SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        void observe() {
+            ContentResolver resolver = mContext.getContentResolver();
+
+            resolver.registerContentObserver(Settings.System.getUriFor(
+                    Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS), false, this,
+                    UserHandle.USER_ALL);
+
+            update();
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            update();
+        }
+
+        public void update() {
+            ContentResolver resolver = mContext.getContentResolver();
+
+            String apps = Settings.System.getStringForUser(resolver,
+                    Settings.System.FORCE_FULLSCREEN_CUTOUT_APPS,
+                    UserHandle.USER_CURRENT);
+            if (apps != null) {
+                setApps(new HashSet<>(Arrays.asList(apps.split(","))));
+            } else {
+                setApps(new HashSet<>());
+            }
+        }
+    }
+}

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -17363,4 +17363,9 @@ public class ActivityManagerService extends IActivityManager.Stub
             return mIsSwipeToScreenshotEnabled && SystemProperties.getBoolean("sys.android.screenshot", false);
         }
     }
+
+    @Override
+    public boolean shouldForceCutoutFullscreen(String packageName) {
+        return mActivityTaskManager.shouldForceCutoutFullscreen(packageName);
+    }
 }

--- a/services/core/java/com/android/server/wm/ActivityRecord.java
+++ b/services/core/java/com/android/server/wm/ActivityRecord.java
@@ -8269,7 +8269,9 @@ final class ActivityRecord extends WindowToken implements WindowManagerService.A
         int activityHeight = containingAppHeight;
 
         if (containingRatio > desiredAspectRatio) {
-            if (containingAppWidth < containingAppHeight) {
+            if (mAtmService.shouldForceCutoutFullscreen(packageName)) {
+                // Use containingAppWidth/Height for maxActivityWidth/Height when force long screen
+            } else if (containingAppWidth < containingAppHeight) {
                 // Width is the shorter side, so we use that to figure-out what the max. height
                 // should be given the aspect ratio.
                 activityHeight = (int) ((activityWidth * desiredAspectRatio) + 0.5f);

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -264,6 +264,8 @@ import com.android.server.statusbar.StatusBarManagerInternal;
 import com.android.server.uri.NeededUriGrants;
 import com.android.server.uri.UriGrantsManagerInternal;
 
+import com.android.internal.util.custom.cutout.CutoutFullscreenController;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileDescriptor;
@@ -776,6 +778,8 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
 
     private int mDeviceOwnerUid = Process.INVALID_UID;
 
+    private CutoutFullscreenController mCutoutFullscreenController;
+
     private final class SettingObserver extends ContentObserver {
         private final Uri mFontScaleUri = Settings.System.getUriFor(FONT_SCALE);
         private final Uri mHideErrorDialogsUri = Settings.Global.getUriFor(HIDE_ERROR_DIALOGS);
@@ -871,6 +875,9 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
 
     public void installSystemProviders() {
         mSettingsObserver = new SettingObserver();
+
+        // Force full screen for devices with cutout
+        mCutoutFullscreenController = new CutoutFullscreenController(mContext);
     }
 
     public void retrieveSettings(ContentResolver resolver) {
@@ -6747,6 +6754,12 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                 final ActivityRecord r = ActivityRecord.isInRootTaskLocked(activityToken);
                 return r != null && r.isInterestingToUserLocked();
             }
+        }
+    }
+
+    public boolean shouldForceCutoutFullscreen(String packageName) {
+        synchronized (this) {
+            return mCutoutFullscreenController.shouldForceCutoutFullscreen(packageName);
         }
     }
 }


### PR DESCRIPTION
Inspired by MIUI and Essential

CutoutFullscreenController: Adapted from https://github.com/LineageOS/android_lineage-sdk/blob/lineage-16.0/sdk/src/java/org/lineageos/internal/applications/LongScreen.java

[cjh1249131356]: Adapt to A12

Author: Jesse Chan <jc@lineageos.org>
Date:   Sat, 21 Apr 2018 23:45:57 -0700

    Add an option to force pre-O apps to use full screen aspect ratio

    When an app target pre-O releases, the default max aspect ratio
    is 1.86:1 which leads to ugly black areas on devices that have
    screens with higher aspect ratio (for example Galaxy S8/S9).

    This change adds an option to allow users to change aspect ratio
    for pre-O apps to full screen aspect ratio.

    Change-Id: I41d5408841593a12443be885e11959bffaebb67b

Signed-off-by: cjh1249131356 <cjh1249131356@gmail.com>
Change-Id: Idba39c0594eecb0a43f33fd97368f0e52d0dffbb
Signed-off-by: chrisw444 <wandersonrodriguesf1@gmail.com>