### PR TITLE
udfps: Trigger onFingerDown with regular action down events too

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsController.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsController.java
@@ -490,7 +490,12 @@ public class UdfpsController implements DozeReceiver {
                     // We need to persist its ID to track it during ACTION_MOVE that could include
                     // data for many other pointers because of multi-touch support.
                     mActivePointerId = event.getPointerId(0);
+                    final int idx = mActivePointerId == -1
+                            ? event.getPointerId(0)
+                            : event.findPointerIndex(mActivePointerId);
                     mVelocityTracker.addMovement(event);
+                    onFingerDown(requestId, (int) event.getRawX(), (int) event.getRawY(),
+                            (int) event.getTouchMinor(idx), (int) event.getTouchMajor(idx));
                     handled = true;
                     mAcquiredReceived = false;
                 }


### PR DESCRIPTION
Previously it was necessary to swipe over the udfps area before HBM gets enabled.

Change-Id: Icf333f13bccfed9ba4ec030716d2bcf83841ef55
Signed-off-by: SageOfD6Path <mail2anirban95@gmail.com>