### PR TITLE
PixelPropsUtils: misc changes

### DIFF
--- a/core/java/com/android/internal/util/superior/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/superior/PixelPropsUtils.java
@@ -38,6 +38,7 @@ public class PixelPropsUtils {
 
     private static final Map<String, Object> propsToChangePixel5;
     private static final Map<String, Object> propsToChangePixel7Pro;
+    private static final Map<String, Object> propsToChangePixel6Pro;
     private static final Map<String, Object> propsToChangePixelXL;
     private static final Map<String, Object> propsToChangeROG1;
     private static final Map<String, Object> propsToChangeXP5;
@@ -47,17 +48,16 @@ public class PixelPropsUtils {
     private static final Map<String, ArrayList<String>> propsToKeep;
 
     private static final String[] packagesToChangePixel7Pro = {
-            "com.google.android.apps.googleassistant",
-            "com.google.android.gms",
             "com.google.android.apps.privacy.wildlife",
             "com.google.android.apps.wallpaper.pixel",
             "com.google.android.apps.wallpaper",
-            "com.google.android.apps.subscriptions.red",
-            "com.google.android.apps.wellbeing",
-            "com.google.android.as",
-            "com.google.android.gms.persistent",
-            "com.google.android.googlequicksearchbox"
+            "com.google.android.apps.subscriptions.red"
+    };
 
+   private static final String[] packagesToChangePixel5 = {
+            "com.google.android.tts",
+            "com.google.android.apps.tachyon",
+            "com.google.android.apps.wellbeing"
     };
 
     private static final String[] packagesToChangePixelXL = {
@@ -75,7 +75,6 @@ public class PixelPropsUtils {
 
     private static final String[] extraPackagesToChange = {
             "com.android.chrome",
-            "com.android.vending",
             "com.breel.wallpapers20",
             "com.nhs.online.nhsonline",
             "com.netflix.mediaclient",
@@ -169,6 +168,13 @@ public class PixelPropsUtils {
         propsToChangePixel7Pro.put("PRODUCT", "cheetah");
         propsToChangePixel7Pro.put("MODEL", "Pixel 7 Pro");
         propsToChangePixel7Pro.put("FINGERPRINT", "google/cheetah/cheetah:13/TQ1A.230205.002/9471150:user/release-keys");
+        propsToChangePixel6Pro = new HashMap<>();
+        propsToChangePixel6Pro.put("BRAND", "google");
+        propsToChangePixel6Pro.put("MANUFACTURER", "Google");
+        propsToChangePixel6Pro.put("DEVICE", "raven");
+        propsToChangePixel6Pro.put("PRODUCT", "raven");
+        propsToChangePixel6Pro.put("MODEL", "Pixel 6 Pro");
+        propsToChangePixel6Pro.put("FINGERPRINT", "google/raven/raven:13/TQ1A.230205.002/9471150:user/release-keys");
         propsToChangePixel5 = new HashMap<>();
         propsToChangePixel5.put("BRAND", "google");
         propsToChangePixel5.put("MANUFACTURER", "Google");
@@ -225,10 +231,6 @@ public class PixelPropsUtils {
                     if (isPixelDevice) return;
                     propsToChange.putAll(propsToChangePixel5);
                 }
-            } else if (packageName.equals("com.netflix.mediaclient") &&
-                        !SystemProperties.getBoolean("persist.sys.pixelprops.netflix", false)) {
-                    if (DEBUG) Log.d(TAG, "Netflix spoofing disabled by system prop");
-                    return;
             } else if (isPixelDevice) {
                 return;
             } else if (packageName.equals("com.android.vending")) {
@@ -239,8 +241,10 @@ public class PixelPropsUtils {
                     propsToChange.putAll(propsToChangePixel7Pro);
                 } else if (Arrays.asList(packagesToChangePixelXL).contains(packageName)) {
                     propsToChange.putAll(propsToChangePixelXL);
-                } else {
+                } else if (Arrays.asList(packagesToChangePixel5).contains(packageName)) {
                     propsToChange.putAll(propsToChangePixel5);
+                } else {
+                    propsToChange.putAll(propsToChangePixel6Pro);
                 }
             }
 


### PR DESCRIPTION
* Flip Pixel 5 with Pixel 6 Pro

* Keep photos , tts , wellbeing and duo on Pixel 5 to avoid TPU

* Fixes camera in google meet/duo

* Drop play store -> fixes google dialer getting updated to pixel version and warn user about incompatibility

* Fix netflix spoof -> we dont wanna add a toggle for it

TEST: check cts , google meet/duo and all gms fuctions
Change-Id: Ic36fee885d900ec40106b844628a0f5636ab9a74

Signed-off-by: optimus9811 vikasyaduvanshi@gmail.com