### PR TITLE
SystemUI: Enable session-based media actions for all apps

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/flags/Flags.kt
+++ b/packages/SystemUI/src/com/android/systemui/flags/Flags.kt
@@ -300,7 +300,7 @@ object Flags {
     val MEDIA_TAP_TO_TRANSFER = unreleasedFlag(900, "media_tap_to_transfer", teamfood = true)
 
     // TODO(b/254512502): Tracking Bug
-    val MEDIA_SESSION_ACTIONS = unreleasedFlag(901, "media_session_actions")
+    val MEDIA_SESSION_ACTIONS = releasedFlag(901, "media_session_actions", teamfood = true)
 
     // TODO(b/254512726): Tracking Bug
     val MEDIA_NEARBY_DEVICES = releasedFlag(903, "media_nearby_devices")


### PR DESCRIPTION
This is required to enable the new play/pause,
previous and next track buttons in QS media player introduced in A13. By default, its only enabled for apps that target API 33:

https://android.googlesource.com/platform/frameworks/base/+/85dddfc3c6d77105eec3e34099ee52928db7cb4a

* (Stallix) - Adapt for A13 QPR1 (after 27195676559382e9feee01e7fc4b120b67f567b3).
* Based on ba8fd9daecf8d36db3b7822fb7c50585da0828bf & db54e85268da34a24e585f95396d4820b2d30242.

Test: Spotify, Telegram, Retro Music
Change-Id: I731a02a8a2c8da770a0e8d55a8d76fe57b48f8fe