### PR TITLE
camera: Add backwards-compatible CaptureResultExtras constructor

### DIFF
--- a/core/java/android/hardware/camera2/impl/CaptureResultExtras.java
+++ b/core/java/android/hardware/camera2/impl/CaptureResultExtras.java
@@ -74,6 +74,20 @@ public class CaptureResultExtras implements Parcelable {
         this.hasReadoutTimestamp = hasReadoutTimestamp;
         this.readoutTimestamp = readoutTimestamp;
     }
+    
+        // Backwards-compatible constructor
+    public CaptureResultExtras(int requestId, int subsequenceId, int afTriggerId,
+                               int precaptureTriggerId, long frameNumber,
+                               int partialResultCount, int errorStreamId,
+                               String errorPhysicalCameraId, long lastCompletedRegularFrameNumber,
+                               long lastCompletedReprocessFrameNumber,
+                               long lastCompletedZslFrameNumber) {
+        this(requestId, subsequenceId, afTriggerId, precaptureTriggerId, frameNumber,
+                partialResultCount, errorStreamId, errorPhysicalCameraId,
+                lastCompletedRegularFrameNumber, lastCompletedReprocessFrameNumber,
+                lastCompletedZslFrameNumber,
+                false /*hasReadOutTimestamp*/, 0 /*readoutTimestamp*/);
+    }
 
     @Override
     public int describeContents() {


### PR DESCRIPTION
Commit e16fed2 added readout timestamp parameters which changed the constructor, but is unsupported by few stock camera apps, such as MIUI Camera.

12-24 09:58:59.536 23375 23492 W System.err: java.lang.NoSuchMethodException: android.hardware.camera2.impl.CaptureResultExtras.<init> [int, int, int, int, long, int, int, class java.lang.String]